### PR TITLE
Support Error objects (and subclasses)

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ function deeper (a, b, ca, cb) {
     : Buffer.isBuffer(a) && Buffer.isBuffer(b) ? bufferSame(a, b)
     : a instanceof Date && b instanceof Date ? a.getTime() === b.getTime()
     : a instanceof RegExp && b instanceof RegExp ? regexpSame(a, b)
+    : a instanceof Error && b instanceof Error ? errorSame(a, b)
     : isArguments(a) ?
       isArguments(b) && deeper(arrayFrom(a), arrayFrom(b), ca, cb)
     : isArguments(b) ? false
@@ -183,6 +184,12 @@ function bufferSame (a, b) {
   return ret
 }
 
+function errorSame (a, b) {
+  return a.name === b.name &&
+    a.message === b.message &&
+    a.stack === b.stack
+}
+
 function shallower (a, b, ca, cb) {
   return typeof a !== 'object' && typeof b !== 'object' && a == b ? true
     : a === null || b === null ? a == b
@@ -191,6 +198,7 @@ function shallower (a, b, ca, cb) {
     : Buffer.isBuffer(a) && Buffer.isBuffer(b) ? bufferSame(a, b)
     : a instanceof Date && b instanceof Date ? a.getTime() === b.getTime()
     : a instanceof RegExp && b instanceof RegExp ? regexpSame(a, b)
+    : a instanceof Error && b instanceof Error ? errorSame(a, b)
     : isArguments(a) || isArguments(b) ?
       shallower(arrayFrom(a), arrayFrom(b), ca, cb)
     : isSet(a) && isSet(b) ? setSame(a, b, ca, cb, shallower)

--- a/test/loose/basic.js
+++ b/test/loose/basic.js
@@ -44,6 +44,25 @@ test('should handle RegExps', function (t) {
   t.end()
 })
 
+test('should handle Errors', function (t) {
+  var e1 = new Error('Foo')
+  var e2 = new Error('Foo')
+  var fe = new Error('Foo Bar')
+  var te = new TypeError('Foo')
+  // Each error has a different stack (by definition), so we must ignore that
+  e1.stack = e2.stack = fe.stack = te.stack = ''
+
+  var oe = { 'message': 'Foo', 'name': 'Error', 'stack': '' }
+
+  t.notOk(same(e1, null), 'Errors are non-null')
+  t.notOk(same(e1, undefined), 'Errors are defined')
+  t.notOk(same(e1, oe), 'Errors are not simple objects')
+  t.notOk(same(e1, te), 'TypeError is an Error, but Error is not a TypeError')
+  t.notOk(same(e1, fe), 'Errors with different messages are not the same')
+  t.ok(same(e1, e2), 'These errors are the same')
+  t.end()
+})
+
 test('should handle functions', function (t) {
   var fnA = function (a) { return a }
   var fnB = function (a) { return a }

--- a/test/strict/basic.js
+++ b/test/strict/basic.js
@@ -107,6 +107,14 @@ test('deeper handles all the edge cases', function (t) {
   t.ok(d(heinous, awful),
     'mutual recursion with otherwise identical structures fools deepEquals')
 
+  // 9. Error objects
+  var e1 = new Error('Foo')
+  var e2 = new Error('Foo')
+  // Each error has a different stack (by definition), so we must ignore that
+  e1.stack = e2.stack = ''
+
+  t.ok(d(e1, e2), 'These errors are the same')
+
   /*
    *
    * FAILURE
@@ -173,6 +181,20 @@ test('deeper handles all the edge cases', function (t) {
 
   awful.granular.stuff[2] = 2
   t.ok(d(heinous, awful), 'small changes should be fixable')
+
+  // 9. Error objects
+  var e3 = new Error('Foo Bar')
+  var e4 = new TypeError('Foo')
+  // Each error has a different stack (by definition), so we must ignore that
+  e3.stack = e4.stack = ''
+
+  var oe = { 'message': 'Foo', 'name': 'Error', 'stack': '' }
+
+  t.notOk(d(e1, null), 'Errors are non-null')
+  t.notOk(d(e1, undefined), 'Errors are defined')
+  t.notOk(d(e1, oe), 'Errors are not simple objects')
+  t.notOk(d(e1, e4), 'TypeError is an Error, but Error is not a TypeError')
+  t.notOk(d(e1, e3), 'Errors with different messages are not the same')
 
   t.end()
 })


### PR DESCRIPTION
I have a need for deeply comparing objects containing `Error`s in `tap`. This PR adds simple support for `Error` objects and its subclasses.